### PR TITLE
add inststructions to make bash run

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## How to build
 
-Install Microsoft Build tools.
+Install Microsoft Build tools as explained [here](https://biapol.github.io/blog/robert_haase/ms_build_tools/). Hint: activate Windows C++ development.
 
 Add the folder where "cl.exe" lives to the PATH, e.g. this one:
 
@@ -22,6 +22,10 @@ Download apache-maven, unzip it and make it part of PATH:
 ```
 C:\programs\apache-maven-3.8.4-bin\apache-maven-3.8.4\bin
 ```
+
+Also install the Windows Subsystem for Linux as explained [here](https://www.groovypost.com/howto/install-and-start-bash-in-windows-10-anniversary-update/)
+and choose [Ubuntu](https://www.microsoft.com/store/productId/9PDXGNCFSCZV) as distribution in the [Windows store](https://aka.ms/wslstore).
+After Ubuntu installation is done in the Windows Store, click on "Open" to finish the installation.
 
 Open the x64 Native Tools Command Prompt for VS 2019 (64 bit!), navigate to the root directory of this project and run
 


### PR DESCRIPTION
Hi Brian @bnorthan ,

I'm not sure if this is necessary. Anyway, when I was trying to run the build using `mvn` I had an error that `bash` was not found and I concluded that WSL and Ubuntu need to be installed to make it work on Windows... If that makes sense, feel free to merge those instructions. If not, I'm happy to close the PR.

Looking forward to our chat on Tuesday!

Best,
Robert