### PR TITLE
Enable-null-parameters

### DIFF
--- a/native/clesperantoj/CMakeLists.txt
+++ b/native/clesperantoj/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # Export all symbols for shared library
 option(BUILD_TESTING  OFF)
 option(BUILD_BENCHMARK  OFF)
 option(BUILD_SHARED_LIBS ON)
-set(CLIC_REPO_TAG 0.10.2) # branch name for dev
+set(CLIC_REPO_TAG 0.11.1) # branch name for dev
 set(CLIC_REPO_URL https://github.com/clEsperanto/CLIc_prototype.git)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/clic)
 

--- a/native/clesperantoj/CMakeLists.txt
+++ b/native/clesperantoj/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # Export all symbols for shared library
 option(BUILD_TESTING  OFF)
 option(BUILD_BENCHMARK  OFF)
 option(BUILD_SHARED_LIBS ON)
-set(CLIC_REPO_TAG 0.11.1) # branch name for dev
+set(CLIC_REPO_TAG master) # branch name for dev
 set(CLIC_REPO_URL https://github.com/clEsperanto/CLIc_prototype.git)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/clic)
 

--- a/native/clesperantoj/include/kernelj.hpp
+++ b/native/clesperantoj/include/kernelj.hpp
@@ -6,10 +6,9 @@
 class Tier1
 {
 public:
-    static ArrayJ absolute(const DeviceJ &dev, const ArrayJ &src, ArrayJ &dst);
-    static ArrayJ absolute(const DeviceJ &dev, const ArrayJ &src);
-    static void gaussianBlur(const DeviceJ &dev, const ArrayJ &src, const ArrayJ &dst, const float &sigmaX, const float &sigmaY, const float &sigmaZ);
-    static void addImageAndScalar(const DeviceJ &dev, const ArrayJ &src, const ArrayJ &dst, const float &scalar);
+    static ArrayJ absolute( DeviceJ *dev, ArrayJ *src, ArrayJ *dst);
+    static ArrayJ gaussianBlur( DeviceJ *dev, ArrayJ *src, ArrayJ *dst,  float sigmaX,  float sigmaY,  float sigmaZ);
+    static ArrayJ addImageAndScalar( DeviceJ *dev, ArrayJ *src, ArrayJ *dst,  float scalar);
 };
 
 #endif // __INCLUDE_KERNELJ_HPP

--- a/native/clesperantoj/src/clesperantoj.cpp
+++ b/native/clesperantoj/src/clesperantoj.cpp
@@ -58,12 +58,12 @@ ArrayJ ArrayJ::create(size_t width, size_t height, size_t depth, size_t dimensio
 
 void ArrayJ::read(void *data) const
 {
-    this->array_->read(data);
+    this->array_->readTo(data);
 }
 
 void ArrayJ::write(void *data) const
 {
-    this->array_->write(data);
+    this->array_->writeFrom(data);
 }
 
 size_t ArrayJ::getWidth()
@@ -117,7 +117,7 @@ void ArrayJ::fillMemory(float value)
 
 void ArrayJ::copyDataTo(ArrayJ &dst)
 {
-    this->array_->copy(dst.get());
+    this->array_->copyTo(dst.get());
 }
 
 // // void Array::getShape(size_t *shape)

--- a/native/clesperantoj/src/kernelj.cpp
+++ b/native/clesperantoj/src/kernelj.cpp
@@ -1,25 +1,18 @@
 #include "kernelj.hpp"
 #include "tier1.hpp"
 
-ArrayJ Tier1::absolute(const DeviceJ &dev, const ArrayJ &src, ArrayJ &dst)
+ArrayJ Tier1::absolute( DeviceJ* dev,  ArrayJ* src, ArrayJ* dst)
 {
-    auto out = cle::tier1::absolute_func(dev.get(), src.get(), dst.get());
-    dst = ArrayJ{out};
-    return dst;
+    return ArrayJ{cle::tier1::absolute_func(dev->get(), src->get(), dst ? dst->get() : nullptr)};
 }
 
-ArrayJ Tier1::absolute(const DeviceJ &dev, const ArrayJ &src)
+ArrayJ Tier1::gaussianBlur(DeviceJ* dev, ArrayJ* src, ArrayJ *dst, float sigmaX, float sigmaY, float sigmaZ)
 {
-    auto out = cle::tier1::absolute_func(dev.get(), src.get(), nullptr);
+    return ArrayJ{cle::tier1::gaussian_blur_func(dev->get(), src->get(), dst ? dst->get() : nullptr, sigmaX, sigmaY, sigmaZ)};
+}
+
+ArrayJ Tier1::addImageAndScalar(DeviceJ * dev, ArrayJ* src, ArrayJ* dst, float scalar)
+{
+    auto out = cle::tier1::add_image_and_scalar_func(dev->get(), src->get(), dst ? dst->get() : nullptr, scalar);
     return ArrayJ{out};
-}
-
-void Tier1::gaussianBlur(const DeviceJ &dev, const ArrayJ &src, const ArrayJ &dst, const float &sigmaX, const float &sigmaY, const float &sigmaZ)
-{
-    cle::tier1::gaussian_blur_func(dev.get(), src.get(), dst.get(), sigmaX, sigmaY, sigmaZ);
-}
-
-void Tier1::addImageAndScalar(const DeviceJ &dev, const ArrayJ &src, const ArrayJ &dst, const float &scalar)
-{
-    cle::tier1::add_image_and_scalar_func(dev.get(), src.get(), dst.get(), scalar);
 }

--- a/src/main/java/net/clesperanto/ClesperantoJ.java
+++ b/src/main/java/net/clesperanto/ClesperantoJ.java
@@ -37,7 +37,7 @@ public class ClesperantoJ {
         currentDevice.setDevice("TX", "all");
 
         ArrayJ input = MemoryJ.makeFloatBuffer(currentDevice, 3, 3, 2, 3, "buffer");
-        ArrayJ output = MemoryJ.makeFloatBuffer(currentDevice, 3, 3, 2, 3, "buffer");
+        // ArrayJ output = MemoryJ.makeFloatBuffer(currentDevice, 3, 3, 2, 3, "buffer");
 
         float data[] = new float[3 * 3 * 2];
         float out[] = new float[3 * 3 * 2];
@@ -47,7 +47,7 @@ public class ClesperantoJ {
         MemoryJ.writeFloatBuffer(input, data, (long) data.length);
         // MemoryJ.writeFloatBuffer(output, out, (long) out.length);
 
-        Tier1.absolute(currentDevice, input, output);
+        ArrayJ output = Tier1.absolute(currentDevice, input, null);
 
         MemoryJ.readFloatBuffer(output, out, (long) out.length);
 

--- a/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
@@ -32,9 +32,10 @@ public class Imglib2ClesperantoJExample {
         Img<FloatType> output_img = ArrayImgs.floats(out, new long[] { 3, 3, 2 });
 
         ArrayJ input = ImgLib2Converters.copyImgLib2ToArrayJ(input_img, currentDevice, "buffer");
-        ArrayJ output = ImgLib2Converters.copyImgLib2ToArrayJ(output_img, currentDevice, "buffer");
+        // ArrayJ output = ImgLib2Converters.copyImgLib2ToArrayJ(output_img,
+        // currentDevice, "buffer");
 
-        Tier1.absolute(currentDevice, input, output);
+        ArrayJ output = Tier1.absolute(currentDevice, input, null);
 
         output_img = ImgLib2Converters.copyArrayJToImgLib2(output);
 


### PR DESCRIPTION
`null` cannot be used because `native` code expect an object, not a pointer.

updating the kernels in native to accepte `ptr` solve the issue.

This however requires to add a `null` test inside the native, but not so much an issue because it should be autogenerated.

closes #41