### PR TITLE
ImagePlus convertion not working

### DIFF
--- a/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
@@ -13,6 +13,9 @@ import net.clesperanto.imagej.ImageJConverters;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
 
 public class ImagePlusClesperantoJExample {
 
@@ -22,39 +25,19 @@ public class ImagePlusClesperantoJExample {
 
         DeviceJ currentDevice = DeviceJ.getDefaultDevice();
 
-        // create a image with 3x3x2 pixels in imglib2
-        float data[] = new float[10 * 10 * 1];
-        float out[] = new float[10 * 10 * 1];
-        Arrays.fill(data, -5);
-        Arrays.fill(out, -1);
-
-        // set middle pixel to 15
-        data[25] = 15;
-
-        ImagePlus input_imp = IJ.createImage("Test", 10, 10, 1, 32);
-        input_imp.getProcessor().setPixels(data);
+        ImagePlus input_imp = IJ.createImage("Test", 10, 10, 2, 32);
+        ImageProcessor ip = input_imp.getStack().getProcessor(1);
+        ip.setf(0, 0, -15.0f);
 
         new ImageJ();
         IJ.run(input_imp, "32-bit", "");
         input_imp.show();
 
         ArrayJ input = ImageJConverters.copyImgLib2ToArrayJ(input_imp, currentDevice, "buffer");
-        // ArrayJ output = ImgLib2Converters.copyImgLib2ToArrayJ(output_img,
-        // currentDevice, "buffer");
-
-        // ArrayJ output = Tier1.absolute(currentDevice, input, null);
-
-        ImagePlus output_imp = ImageJConverters.copyArrayJToImgLib2(input);
+        ArrayJ output = Tier1.absolute(currentDevice, input, null);
+        ImagePlus output_imp = ImageJConverters.copyArrayJToImgLib2(output);
+        
         output_imp.show();
-
-        // print out each pixel value of the output image
-        // float[] output_pixels = (float[]) output_imp.getProcessor().getPixels();
-        // for (int i = 0; i < output_pixels.length; i++) {
-        // System.out.println("out[" + i + "] = " + output_pixels[i]);
-        // }
-
-        // Float sum = Tier2.sumOfAllPixels(currentDevice, output);
-        // System.out.println("Sum of all pixels: " + sum);
     }
 
 }

--- a/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
@@ -1,0 +1,60 @@
+package net.clesperanto;
+
+import java.util.Arrays;
+
+import net.clesperanto.core.DeviceJ;
+import net.clesperanto.core.MemoryJ;
+import net.clesperanto.core.BackendJ;
+import net.clesperanto.core.ArrayJ;
+
+import net.clesperanto.kernels.Tier1;
+import net.clesperanto.imagej.ImageJConverters;
+
+import ij.IJ;
+import ij.ImageJ;
+import ij.ImagePlus;
+
+public class ImagePlusClesperantoJExample {
+
+    public static void main(String[] args) {
+        System.out.println("Hello World! Native Java");
+        System.out.println(System.getProperty("java.library.path"));
+
+        DeviceJ currentDevice = DeviceJ.getDefaultDevice();
+
+        // create a image with 3x3x2 pixels in imglib2
+        float data[] = new float[10 * 10 * 1];
+        float out[] = new float[10 * 10 * 1];
+        Arrays.fill(data, -5);
+        Arrays.fill(out, -1);
+
+        // set middle pixel to 15
+        data[25] = 15;
+
+        ImagePlus input_imp = IJ.createImage("Test", 10, 10, 1, 32);
+        input_imp.getProcessor().setPixels(data);
+
+        new ImageJ();
+        IJ.run(input_imp, "32-bit", "");
+        input_imp.show();
+
+        ArrayJ input = ImageJConverters.copyImgLib2ToArrayJ(input_imp, currentDevice, "buffer");
+        // ArrayJ output = ImgLib2Converters.copyImgLib2ToArrayJ(output_img,
+        // currentDevice, "buffer");
+
+        // ArrayJ output = Tier1.absolute(currentDevice, input, null);
+
+        ImagePlus output_imp = ImageJConverters.copyArrayJToImgLib2(input);
+        output_imp.show();
+
+        // print out each pixel value of the output image
+        // float[] output_pixels = (float[]) output_imp.getProcessor().getPixels();
+        // for (int i = 0; i < output_pixels.length; i++) {
+        // System.out.println("out[" + i + "] = " + output_pixels[i]);
+        // }
+
+        // Float sum = Tier2.sumOfAllPixels(currentDevice, output);
+        // System.out.println("Sum of all pixels: " + sum);
+    }
+
+}

--- a/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/ImagePlusClesperantoJExample.java
@@ -36,7 +36,7 @@ public class ImagePlusClesperantoJExample {
         ArrayJ input = ImageJConverters.copyImgLib2ToArrayJ(input_imp, currentDevice, "buffer");
         ArrayJ output = Tier1.absolute(currentDevice, input, null);
         ImagePlus output_imp = ImageJConverters.copyArrayJToImgLib2(output);
-        
+
         output_imp.show();
     }
 

--- a/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
@@ -37,6 +37,9 @@ public class Imglib2ClesperantoJExample {
 
         ArrayJ output = Tier1.absolute(currentDevice, input, null);
 
+        System.out.println("Input:" + input.toString());
+        System.out.println("Output:" + output.toString());
+
         output_img = ImgLib2Converters.copyArrayJToImgLib2(output);
 
         output_img.cursor().forEachRemaining(t -> System.out.println(t.get()));

--- a/src/main/java/net/clesperanto/core/ArrayJ.java
+++ b/src/main/java/net/clesperanto/core/ArrayJ.java
@@ -98,6 +98,14 @@ public class ArrayJ {
     }
 
     /**
+     *
+     * @return a string representation of the array information
+     */
+    public String toString() {
+        return "cle::Array[(" + this.getWidth() + ","+ this.getHeight() + ","+ this.getDepth() + "), dtype=" + this.getDataType() + ", mtype=" + this.getMemoryType() + "]";
+    }
+
+    /**
      * Fill the array in the GPU with the wanted value.
      * All the positions in the array will be set to the same value
      * @param value

--- a/src/main/java/net/clesperanto/core/MemoryJ.java
+++ b/src/main/java/net/clesperanto/core/MemoryJ.java
@@ -905,11 +905,11 @@ public class MemoryJ {
 	private static long[] transformDims(long[] dims) {
 		switch (dims.length) {
 			case 3:
-				return new long[] {dims[0], dims[1], dims[2]};	
+				return new long[] {dims[0], dims[1], dims[2]};
 			case 2:
 				return new long[] {dims[0], dims[1], 1};
 			case 1:
-				return new long[] {dims[0], 1, 1};	
+				return new long[] {dims[0], 1, 1};
 			default:
 				throw new IllegalArgumentException();
 		}

--- a/src/main/java/net/clesperanto/core/MemoryJ.java
+++ b/src/main/java/net/clesperanto/core/MemoryJ.java
@@ -903,13 +903,15 @@ public class MemoryJ {
 	}
 
 	private static long[] transformDims(long[] dims) {
-		if (dims.length > 3)
-			throw new IllegalArgumentException();
-		else if (dims.length == 0)
-			throw new IllegalArgumentException();
-		else if (dims.length == 1)
-			return new long[] {dims[0], 1, 1};
-		else
-			return new long[] {dims[0], dims[1], 1};
+		switch (dims.length) {
+			case 3:
+				return new long[] {dims[0], dims[1], dims[2]};	
+			case 2:
+				return new long[] {dims[0], dims[1], 1};
+			case 1:
+				return new long[] {dims[0], 1, 1};	
+			default:
+				throw new IllegalArgumentException();
+		}
 	}
 }

--- a/src/main/java/net/clesperanto/imagej/ImageJConverters.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJConverters.java
@@ -88,7 +88,7 @@ public class ImageJConverters {
 	    		    }
 	    	    }
 		    }
-	    }	
+	    }
 
 	    return dataType.makeAndWriteArrayJ(flatArr, device, dims, memoryType);
 	}

--- a/src/main/java/net/clesperanto/imagej/ImageJConverters.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJConverters.java
@@ -94,7 +94,7 @@ public class ImageJConverters {
 	}
 
 	private static ImagePlus fromBuffer(ByteBuffer byteBuffer, ImageJDataType type, long[] dimensions) {
-	    ImagePlus im = IJ.createImage("image", (int) dimensions[0], (int) dimensions[1], (int) dimensions[2], type.createType());
+	    ImagePlus im = IJ.createImage("image", (int) dimensions[0], (int) dimensions[1], (int) dimensions[2], type.getBitDepth());
 
 	    switch (type) {
 	        case FLOAT32:

--- a/src/main/java/net/clesperanto/imagej/ImageJConverters.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJConverters.java
@@ -88,7 +88,7 @@ public class ImageJConverters {
 	    		    }
 	    	    }
 		    }
-	    }
+	    }	
 
 	    return dataType.makeAndWriteArrayJ(flatArr, device, dims, memoryType);
 	}
@@ -134,16 +134,10 @@ public class ImageJConverters {
 		sizeMap.put("c", imp.getNChannels());
 		sizeMap.put("z", imp.getNSlices());
 		sizeMap.put("t", imp.getNFrames());
+
 		sizeMap = sizeMap.entrySet().stream()
-				.filter(ee -> ee.getValue() == 1).collect(Collectors.toMap(ee -> ee.getKey(), ee -> ee.getValue()));
-		while (sizeMap.entrySet().size() > 3) {
-			if (sizeMap.get("t") != null)
-				sizeMap.remove("t");
-			else if (sizeMap.get("c") != null)
-				sizeMap.remove("c");
-			else if (sizeMap.get("z") != null)
-				sizeMap.remove("z");
-		}
+				.filter(ee -> ee.getValue() != 1).collect(Collectors.toMap(ee -> ee.getKey(), ee -> ee.getValue()));
+
 		int tot = 1;
 		for (Integer vv : sizeMap.values()) {
 			tot *= vv;

--- a/src/main/java/net/clesperanto/imagej/ImageJDataType.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJDataType.java
@@ -8,20 +8,18 @@ import net.clesperanto.core.DataType;
 import net.clesperanto.core.DeviceJ;
 // TODO add all types ImagePlus.GRAY8, ImagePlus.GRAY16, ImagePlus.GRAY32, ImagePlus.COLOR_256 or ImagePlus.COLOR_RGB)
 public enum ImageJDataType {
-    FLOAT32(DataType.fromString("float"), ImagePlus.GRAY32, float[].class, 32),
-    UINT16(DataType.fromString("ushort"), ImagePlus.GRAY16, short[].class, 16),
-    UINT8(DataType.fromString("uchar"), ImagePlus.GRAY8, byte[].class, 8);
+    FLOAT32(DataType.fromString("float"), ImagePlus.GRAY32, float[].class),
+    UINT16(DataType.fromString("ushort"), ImagePlus.GRAY16, short[].class),
+    UINT8(DataType.fromString("uchar"), ImagePlus.GRAY8, byte[].class);
 
 	private final DataType dt;
     private final int imgDtype;
-    private final int bitDepth;
     private final Class<?> arrayClass;
 
-    ImageJDataType(DataType dt, int imgDtype, Class<?> arrayClass, int bitDepth) {
+    ImageJDataType(DataType dt, int imgDtype, Class<?> arrayClass) {
         this.dt = dt;
         this.imgDtype = imgDtype;
         this.arrayClass = arrayClass;
-        this.bitDepth = bitDepth;
     }
 
     public static ImageJDataType fromString(String dType) {
@@ -54,10 +52,6 @@ public enum ImageJDataType {
     	return dt.getByteSize();
     }
 
-    public int getBitDepth() {
-    	return this.bitDepth;
-    }
-
     public void readToBuffer(ArrayJ arrayj, ByteBuffer buffer) {
     	this.dt.readToBuffer(arrayj, buffer);
     }
@@ -75,7 +69,7 @@ public enum ImageJDataType {
     }
 
     public int createType() {
-        return this.imgDtype;
+        return this.getByteSize() * 8;
     }
 
     public void putValInArray(Object arr, int pos, Number value) {

--- a/src/main/java/net/clesperanto/imagej/ImageJDataType.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJDataType.java
@@ -8,18 +8,20 @@ import net.clesperanto.core.DataType;
 import net.clesperanto.core.DeviceJ;
 // TODO add all types ImagePlus.GRAY8, ImagePlus.GRAY16, ImagePlus.GRAY32, ImagePlus.COLOR_256 or ImagePlus.COLOR_RGB)
 public enum ImageJDataType {
-    FLOAT32(DataType.fromString("float"), ImagePlus.GRAY32, float[].class),
-    UINT16(DataType.fromString("ushort"), ImagePlus.GRAY16, short[].class),
-    UINT8(DataType.fromString("uchar"), ImagePlus.GRAY8, byte[].class);
+    FLOAT32(DataType.fromString("float"), ImagePlus.GRAY32, float[].class, 32),
+    UINT16(DataType.fromString("ushort"), ImagePlus.GRAY16, short[].class, 16),
+    UINT8(DataType.fromString("uchar"), ImagePlus.GRAY8, byte[].class, 8);
 
 	private final DataType dt;
     private final int imgDtype;
+    private final int bitDepth;
     private final Class<?> arrayClass;
 
-    ImageJDataType(DataType dt, int imgDtype, Class<?> arrayClass) {
+    ImageJDataType(DataType dt, int imgDtype, Class<?> arrayClass, int bitDepth) {
         this.dt = dt;
         this.imgDtype = imgDtype;
         this.arrayClass = arrayClass;
+        this.bitDepth = bitDepth;
     }
 
     public static ImageJDataType fromString(String dType) {
@@ -50,6 +52,10 @@ public enum ImageJDataType {
 
     public int getByteSize() {
     	return dt.getByteSize();
+    }
+
+    public int getBitDepth() {
+    	return this.bitDepth;
     }
 
     public void readToBuffer(ArrayJ arrayj, ByteBuffer buffer) {

--- a/src/main/java/net/clesperanto/imagej/ImageJDataType.java
+++ b/src/main/java/net/clesperanto/imagej/ImageJDataType.java
@@ -6,6 +6,7 @@ import ij.ImagePlus;
 import net.clesperanto.core.ArrayJ;
 import net.clesperanto.core.DataType;
 import net.clesperanto.core.DeviceJ;
+
 // TODO add all types ImagePlus.GRAY8, ImagePlus.GRAY16, ImagePlus.GRAY32, ImagePlus.COLOR_256 or ImagePlus.COLOR_RGB)
 public enum ImageJDataType {
     FLOAT32(DataType.fromString("float"), ImagePlus.GRAY32, float[].class),


### PR DESCRIPTION
The converter between ArrayJ and ImagePlus does not seems to work correctly.

I have an issue with a wrong bitdepth provided during the convertion `ArrayJ` to `ImagePlus`, most likely because of this:
https://github.com/clEsperanto/clesperantoj_prototype/blob/f82b508d50c53f330b97d189a7ee5e48d1a0c569/src/main/java/net/clesperanto/imagej/ImageJDataType.java#L71-L73
which return the enum int (2 for float) instead of the bitdepth required for `IJ.createImage()`

But I think there is an other issue as the even if I try with the correct bitdepth, the output ImagePlus from `ImageJcopyArrayJtoImgLib2()` seems empty.