### PR TITLE
add CI for auto update tier code

### DIFF
--- a/.github/workflows/auto_update_tier.yaml
+++ b/.github/workflows/auto_update_tier.yaml
@@ -1,0 +1,31 @@
+name: Auto Update Tiers
+
+on:
+  repository_dispatch:
+    types: [clic_update]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'CLIc tag'
+        required: true
+        default: 'master'
+
+jobs:
+  run-cle-roboto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print release tag
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag || github.event.inputs.release_tag }}
+        run: |
+          echo "Received release tag: $RELEASE_TAG from CLIc"
+
+      - name: Get python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Use cle-roboto to update tiers
+        uses: clEsperanto/cle-roboto-repo@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This introduce a workflow which will call the auto update action on the clesperantoJ repo when a new release of CLIc is done or manually triggered