### PR TITLE
Bump to CLIc version 0.13.0

### DIFF
--- a/native/clesperantoj/CMakeLists.txt
+++ b/native/clesperantoj/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # Export all symbols for shared library
 option(BUILD_TESTING  OFF)
 option(BUILD_BENCHMARK  OFF)
 option(BUILD_SHARED_LIBS ON)
-set(CLIC_REPO_TAG 0.12.1) # branch name for dev
+set(CLIC_REPO_TAG 0.13.0) # branch name for dev
 set(CLIC_REPO_URL https://github.com/clEsperanto/CLIc_prototype.git)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/clic)
 


### PR DESCRIPTION
With 0.12.1 doesn't build 
```
./target/classes/net/clesperanto/macosx-arm64/libjnijclic.dylib
./target/classes/net/clesperanto/macosx-arm64/libjnikernelj.dylib
```
on macos