### PR TITLE
Limit number of parallel jobs for make -j

### DIFF
--- a/native/clesperantoj/cppbuild.sh
+++ b/native/clesperantoj/cppbuild.sh
@@ -18,7 +18,7 @@ case $PLATFORM in
             #    -DCMAKE_CUDA_HOST_COMPILER="/usr/bin/g++" \
             #    -DOPENCL_INCLUDE_DIR="/usr/local/cuda/include/" \
 		# -DCLFFT_LIBRARY_DIR="/opt/OpenCL/clFFT-2.12.2-Linux-x64/lib64/" ..
-        make -j
+        make -j$(nproc)
         make install
         ;;
     macosx-*)
@@ -30,7 +30,7 @@ case $PLATFORM in
         #        -DCMAKE_CXX_COMPILER="g++" \
         #        -DCMAKE_CUDA_HOST_COMPILER="g++" \
 		# -DCLFFT_LIBRARY_DIR="/Users/haase/Downloads/clfft-2.12.2-h83d4a3d_1/lib" ..
-        make -j
+        make -j$(sysctl -n hw.ncpu)
         make install
         ;;
     windows-x86_64)


### PR DESCRIPTION
Limit the number of parallel make jobs to the number of cores.
With unlimited parallelism, for me, the build takes forever (paradoxically...)