### PR TITLE
add CI

### DIFF
--- a/.github/workflows/auto_update.yaml
+++ b/.github/workflows/auto_update.yaml
@@ -1,0 +1,31 @@
+name: Auto Update
+
+on:
+  repository_dispatch:
+    types: [clic_update]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'CLIc tag'
+        required: true
+        default: 'master'
+
+jobs:
+  run-cle-roboto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print release tag
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag || github.event.inputs.release_tag }}
+        run: |
+          echo "Received release tag: $RELEASE_TAG from CLIc"
+
+      - name: Get python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Use cle-roboto to update tiers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: clEsperanto/cle-roboto-repo@v1


### PR DESCRIPTION
Add CI with cle-roboto for automatically updating kernels based on CLIc release
Behave identically as the one for pyclesperanto

The CI must be manually trigger for now (as a security) 