### PR TITLE
Remove-old-ArrayJ-constructor

### DIFF
--- a/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
+++ b/src/main/java/net/clesperanto/Imglib2ClesperantoJExample.java
@@ -29,16 +29,12 @@ public class Imglib2ClesperantoJExample {
         Img<FloatType> output_img = ArrayImgs.floats(out, new long[] { 3, 3, 2 });
 
         ArrayJ input = ImgLib2Converters.copyImgLib2ToArrayJ(input_img, currentDevice, MemoryType.BUFFER);
-        // ArrayJ output = ImgLib2Converters.copyImgLib2ToArrayJ(output_img,
-        // currentDevice, "buffer");
-
         ArrayJ output = Tier1.absolute(currentDevice, input, null);
 
         System.out.println("Input:" + input.toString());
         System.out.println("Output:" + output.toString());
 
         output_img = ImgLib2Converters.copyArrayJToImgLib2(output);
-
         output_img.cursor().forEachRemaining(t -> System.out.println(t.get()));
 
         Float sum = Tier2.sumOfAllPixels(currentDevice, output);

--- a/src/main/java/net/clesperanto/core/ArrayJ.java
+++ b/src/main/java/net/clesperanto/core/ArrayJ.java
@@ -45,10 +45,10 @@ public class ArrayJ {
         numDimensions = _arrayj.getDimension();
     }
 
-    // TODO: remove after adapting Tier methods
-    public ArrayJ(final _ArrayJ _arrayj, Object IGNORED_just_so_that_Tier_methods_work_unmodified_REMOVE_LATER) {
-        this(_arrayj);
-    }
+    // // TODO: remove after adapting Tier methods
+    // public ArrayJ(final _ArrayJ _arrayj, Object IGNORED_just_so_that_Tier_methods_work_unmodified_REMOVE_LATER) {
+    //     this(_arrayj);
+    // }
 
     // TODO: make package-private?
     public ArrayJ(final long width, final long height, final long depth, final int numDimensions,


### PR DESCRIPTION
gencle was updated, no need to keep the old ArrayJ constructor function with device parameter